### PR TITLE
Continuum.Route

### DIFF
--- a/demo/public/index.js
+++ b/demo/public/index.js
@@ -6,7 +6,7 @@
  * @description
  */
 import Continuum from 'continuum';
-import Router from '~/system/router';
+import Route from '~/system/route';
 import View from '~/system/view';
 
 
@@ -21,13 +21,37 @@ import home from './home';
  * View List - gets passed to router for binding.
  * @type {Array}
  */
-const views = [
-  new View('/', home, {protected: false, transition: true})
-];
+const views = {
+  '/': new View(home)
+};
+
+/**
+ * Access rules for each route.
+ * @type {Object}
+ */
+const rules = {
+  '/': {protected: false, restricted: false}
+};
+
+/**
+ * Application Routes
+ * @type {[type]}
+ */
+const routes = Object.keys(views)
+  .map(view => new Route(
+    view,
+    views[view].render.bind(views[view]),
+    rules[view]));
 
 //
 // ROUTER INIT
 //------------------------------------------------------------------------------------------//
 // @description
 //
-const router = new Router().register(views).start();
+const router = new Continuum.Router();
+
+// Register each route.
+routes.forEach(route => router.register(route.path, route.load.bind(route)));
+
+// Start the router.
+router.start();

--- a/demo/system/route.js
+++ b/demo/system/route.js
@@ -12,9 +12,9 @@ import Access from './access';
 /**
  * Wraps Continuum.Router to provide custom auth and acl checks.
  */
-export default class Router extends Continuum.Router {
-  constructor() {
-    super();
+export default class Route extends Continuum.Route {
+  constructor(path='/', handler, config={}) {
+    super(path, handler, config);
   }
 
   /**
@@ -23,8 +23,8 @@ export default class Router extends Continuum.Router {
    * @param  {[type]} router [description]
    * @return {[type]}        [description]
    */
-  protect(view, router) {
-    console.log(view, router)
+  protect(router) {
+    return true;
   }
 
   /**
@@ -32,7 +32,7 @@ export default class Router extends Continuum.Router {
    * @param  {[type]} view [description]
    * @return {[type]}      [description]
    */
-  restrict(view) {
+  restrict(router) {
     return true;
   }
 }

--- a/demo/system/view.js
+++ b/demo/system/view.js
@@ -11,14 +11,15 @@ import Dom from 'react-dom';
 import Constants from '~/system/constants';
 
 /**
- * Wraps the Continuum.View class to provide the react specific way to render something.
+ * Wraps the Continuum.View class to provide the react configific way to render something.
  * So if we ever decide to change rendering libraries, we can just change what the render function
  * does without Continuum being prescriptive.
  * @type {[type]}
  */
 export default class View extends Continuum.View {
-  constructor(route, component, spec) {
-    super(route, spec);
+  constructor(component, config={}) {
+    super(component, config);
+
     this.component = component;
   }
 
@@ -30,7 +31,7 @@ export default class View extends Continuum.View {
    * @return {[type]}        [description]
    */
   render(params) {
-   this.instance = Dom.render(<this.component params={params} />, document.getElementById(Constants.mountpoint));
+   this.instance = Dom.render(<this.component params={params} view={this}/>, document.getElementById(Constants.mountpoint));
   }
 
   /**
@@ -38,7 +39,7 @@ export default class View extends Continuum.View {
    * @return {[type]} [description]
    */
   transitionStart() {
-    if(!this.spec.transition) return;
+    if(!this.config.transition) return;
 
     console.log('transition started');
   }
@@ -48,7 +49,7 @@ export default class View extends Continuum.View {
    * @return {[type]} [description]
    */
   transitionStop() {
-    if(!this.spec.transition) return;
+    if(!this.config.transition) return;
 
     console.log('transition stopped');
   }

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ const Utils = require('./utils');
 const Security = require('./security');
 const Model = require('./model');
 const Router = require('./router');
+const Route = require('./route');
 const View = require('./view');
 
 /**
@@ -23,4 +24,4 @@ const View = require('./view');
  */
 module.exports = {
   Security, Domain, Service,
-  Store, Data, Utils, Model, View, Router, Resource, Structs};
+  Store, Data, Utils, Model, View, Router, Resource, Structs, Route};

--- a/src/route.js
+++ b/src/route.js
@@ -1,0 +1,59 @@
+'use strict';
+
+/***********************************************************************************************************************************************
+ * CONTINUUM - ROUTE
+ ***********************************************************************************************************************************************
+ * @description
+ */
+
+module.exports = class Route {
+  constructor(path='/', handler=()=>{}, config={}) {
+    this.config = Object.assign({
+      protected: true,
+      restricted: true
+    }, config);
+
+    this.path = path;
+    this.handler = handler;
+    this.strategies = {protected: this.protect, restricted: this.restrict};
+  }
+
+  /**
+   * [protect description]
+   * @param  {[type]} view [description]
+   * @return {[type]}      [description]
+   */
+  protect(router) {
+    return new Promise((resolve, reject) => {
+      reject(`Continuum:Route - [${router.get()}] is marked as protected. Continuum does not enforce any authentication system. See the project wiki for more information.`)
+    });
+  }
+
+  /**
+   * [restrict description]
+   * @param  {[type]} view [description]
+   * @return {[type]}      [description]
+   */
+  restrict(router) {
+    return new Promise((resolve, reject) => {
+      reject(`Continuum:Route - [${router.get()}] is marked as restricted. Continuum does not enforce any access control system. See the project wiki for more information.`);
+    });
+  }
+
+  /**
+   * Parses View strategies and ultimately invokes the view's render function.
+   * @param  {[type]} router [description]
+   * @param  {[type]} view   [description]
+   * @return {[type]}        [description]
+   */
+  load(router, params) {
+    let strategies = Object.keys(this.strategies).filter(strategy => this.config[strategy])
+      .map(strategy => this.strategies[strategy](router, params));
+
+    Promise.all(strategies)
+      .then(() => this.handler(params))
+      .catch(e => {console.error(`Continuum:Router - Error loading route: ${router.get()} - ${e}`)}); // move to debug module
+
+    return this;
+  }
+}

--- a/src/router.js
+++ b/src/router.js
@@ -1,13 +1,12 @@
 'use strict';
 
 /***********************************************************************************************************************************************
- * SYSTEM - ROUTER
+ * CONTINUUM - ROUTER
  ***********************************************************************************************************************************************
  * @description
  */
 const Director = require('director/build/director');
 const Pattern = require('url-pattern');
-const View = require('./view');
 
 /**
  * Create a singleton, private instance of the router
@@ -23,32 +22,7 @@ const _router = new Director.Router();
  */
 module.exports = class Router {
   constructor() {
-    this.start = start.bind(this, _router);
-    this.register = register.bind(this, _router);
-    this.render = render.bind(this, _router);
-    this.strategies = {protected: this.protect, restricted: this.restrict};
-  }
 
-  /**
-   * [protect description]
-   * @param  {[type]} view [description]
-   * @return {[type]}      [description]
-   */
-  protect(view) {
-    return new Promise((resolve, reject) => {
-      reject(`Continuum:Router - view: [${view.route}] is marked as protected. Continuum does not enforce any authentication system. See the project wiki for more information.`)
-    });
-  }
-
-  /**
-   * [restrict description]
-   * @param  {[type]} view [description]
-   * @return {[type]}      [description]
-   */
-  restrict(view) {
-    return new Promise((resolve, reject) => {
-      reject(`Continuum:Router - view: [${view.route}] is marked as restricted. Continuum does not enforce any access control system. See the project wiki for more information.`);
-    });
   }
 
   /**
@@ -65,6 +39,29 @@ module.exports = class Router {
    */
   get() {
     return _router.getRoute();
+  }
+
+  /**
+   * Initializes Director
+   * @return {[type]} [description]
+   */
+  start(router, mode='#/') {
+    _router.init(mode);
+    return this;
+  }
+
+  /**
+   * Registers a collection of routes
+   * @param  {Object} [routes={}] [description]
+   * @return {[type]}             [description]
+   */
+  register(path='/', fn=this.stub) {
+
+    _router.on(path, (params)=>{
+      fn(this, this.params.map(path, params))
+    });
+
+    return this;
   }
 
   /**
@@ -86,65 +83,17 @@ module.exports = class Router {
 //------------------------------------------------------------------------------------------//
 // @description
 //
-
-/**
- * Initializes Director
- * @return {[type]} [description]
- */
-function start(router, mode='#/') {
-  router.init(mode);
-  return this;
-}
-
-/**
- * Registers a collection of routes
- * @param  {Object} [routes={}] [description]
- * @return {[type]}             [description]
- */
-function register(router, views=[]) {
-
-  if(views && views.constructor !== Array) {
-   views = [views]
-  }
-
-  views.filter(view => view instanceof View).forEach(view => {
-    router.on(view.route, this.render.bind(this, view));
-  });
-
-  return this;
-};
-
-/**
- * Parses View strategies and ultimately invokes the view's render function.
- * @param  {[type]} router [description]
- * @param  {[type]} view   [description]
- * @return {[type]}        [description]
- */
-function render(router, view) {
-  view.transitionStart();
-
-  let strategies = Object.keys(this.strategies).filter(strategy => view.spec[strategy])
-    .map(strategy => this.strategies[strategy](view, router));
-
-  Promise.all(strategies)
-    .then(view.transitionStop)
-    .then(() => view.render(this.params.map(view, Array.apply(null, arguments).slice(2))))
-    .catch(e => {console.error(`Continuum:Router - Error loading route: ${view.route} - ${e}`)}); // move to debug module
-
-  return this;
-}
-
 /**
  * Builds url params from dynamic segments into a map.
  * ie: registered: /users/:id - visited: /users/10 will return an object of {id: 10};
  *
- * @param  {[type]} view        [description]
+ * @param  {[type]} path        [description]
  * @param  {Array}  [params=[]] [description]
  * @return {[type]}             [description]
  */
-function mapParamsFromRoute(view, params=[]) {
+function mapParamsFromRoute(path, params=[]) {
   const map = {};
-  const pattern = new Pattern(view.route, {segmentNameCharset: 'a-zA-Z0-9_-'});
+  const pattern = new Pattern(path, {segmentNameCharset: 'a-zA-Z0-9_-'});
 
   (pattern.names || []).forEach((name, idx) => {
     map[name] = params[idx];

--- a/src/view.js
+++ b/src/view.js
@@ -11,14 +11,13 @@
  * @type {String}
  */
 module.exports = class View {
-  constructor(route='', spec={}) {
-    if(!route) {
-      throw new Error(`Continuum:View - needs a url to register`);
+  constructor(view, config={}) {
+    if(!view) {
+      throw new Error(`Continuum:View - needs a view to register`);
     }
 
     // Instance Members
-    this.route = route;
-    this.spec = Object.assign({protected: true}, spec);
+    this.config = Object.assign({protected: true}, config);
     this.transitionStart = this.transitionStart.bind(this);
     this.transitionStop = this.transitionStop.bind(this);
   }


### PR DESCRIPTION
Overtime it became gross to me that Continuum.Router _knew_ about a `render` function. It may not have known what it did, but it meant that whatever you gave to Continuum.Router had to be an instanceof Continuum.View (essentially).

With the addition of Continuum.Route, everything now is just registered handlers. No system has any knowledge of each other's API. Meaning that each component can be used independently.