### PR TITLE
Resource

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,5 +15,5 @@ test:
         background: true
   override:
     - sleep 30
-    - npm run tests:unit
+    - npm run tests:unit:headless
     - npm run tests:ui:headless

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "exit 0",
     "demo:server": "./node_modules/.bin/webpack-dev-server --config ./demo/webpack.config.js --env.API=http://localhost:9000 --env.PORT=9001",
     "demo:seed": "node ./demo/.scripts/seed",
-    "tests:unit": "API=http://localhost:9000 node ./tests/unit",
+    "tests:unit": "API=http://localhost:9000 node --inspect --inspect-brk ./tests/unit",
+    "tests:unit:headless": "API=http://localhost:9000 node ./tests/unit",
     "tests:ui": "./node_modules/.bin/cypress open",
     "tests:ui:headless": "./node_modules/.bin/cypress run",
     "ci": "git add . && git commit -m \"CI Changes\" && git push"

--- a/src/data.js
+++ b/src/data.js
@@ -24,7 +24,7 @@ function mapify(data=[], map={}) {
     throw new Error(`Continuum:Data - Mapify - This function is intended to convert Array instance data into a map by a given map, was given: ${map} - instead`);
   }
 
-  // BUild top level map items
+  // Build top level map items
   Object.keys(map).forEach(key => mapping[key] = {});
 
   // Loop through data and

--- a/src/domain.js
+++ b/src/domain.js
@@ -90,7 +90,7 @@ module.exports = class Domain {
     config = Object.assign(this.config, config);
 
     return new Promise((resolve, reject) => {
-      this.Resource.put(this.Service.outbound.update(data), config)
+      this.Resource.put(config, this.Service.outbound.update(data))
         .then(response => this.Service.inbound.update(response, data))
         .then(data => {
           if(config.cache) {
@@ -128,7 +128,7 @@ module.exports = class Domain {
     config = Object.assign(this.config, config);
 
     return new Promise((resolve, reject) => {
-      this.Resource.post(this.Service.outbound.create(data), config)
+      this.Resource.post(config, this.Service.outbound.create(data))
         .then(response => this.Service.inbound.create(response, data))
         .then(data => {
           if(!config.cache) return data;
@@ -165,7 +165,7 @@ module.exports = class Domain {
     config = Object.assign(this.config, config);
 
     return new Promise((resolve, reject) => {
-      this.Resource.delete(this.Service.outbound.delete(data), config)
+      this.Resource.delete(config, this.Service.outbound.delete(data))
         .then(response => {
           if(!config.cache) return response;
 

--- a/src/domain.js
+++ b/src/domain.js
@@ -165,7 +165,7 @@ module.exports = class Domain {
     config = Object.assign(this.config, config);
 
     return new Promise((resolve, reject) => {
-      this.Resource.delete(data, config)
+      this.Resource.delete(this.Service.outbound.delete(data), config)
         .then(response => {
           if(!config.cache) return response;
 

--- a/src/resource/index.js
+++ b/src/resource/index.js
@@ -8,6 +8,7 @@
 const Axios = require('axios');
 const path = require('path');
 const Response = require('./response');
+const Request = require('./request');
 const Pattern = require('url-pattern');
 
 /**
@@ -29,59 +30,48 @@ module.exports = class Resource {
     if(!this.resource) {
       throw new Error(`System.Resource - please provice a resource name to use`);
     }
+
+    // Request wrapper bindings.
+    this.get = request.bind(this, 'get');
+    this.put = request.bind(this, 'put');
+    this.post = request.bind(this, 'post');
+    this.delete = request.bind(this, 'delete');
   }
 
   /**
-   * Axios HTTP GET wrapper
-   * @param  {[type]} config [description]
-   * @return {[type]}        [description]
-   */
-  get(config={}) {
-    return Axios.get(this.uri(config.segments || {}, config, this.methods['get']), config).then(res => new Response(res));
-  }
-
-  /**
-   * Axios HTTP PUT wrapper
-   * @param  {[type]} config [description]
-   * @return {[type]}        [description]
-   */
-  put(data={}, config={}) {
-    return Axios.put(this.uri(data, config, this.methods['put']), data, config).then(res => new Response(res));
-  }
-
-  /**
-   * Axios HTTP POST wrapper
-   * @param  {[type]} config [description]
-   * @return {[type]}        [description]
-   */
-  post(data={}, config={}) {
-    return Axios.post(this.uri(data, config, this.methods['post']), data, config).then(res => new Response(res));
-  }
-
-  /**
-   * Axios HTTP DELETE wrapper
-   * @param  {Object} [data={}]   [description]
+   * Builds a fully qualified URL
    * @param  {Object} [config={}] [description]
    * @return {[type]}             [description]
    */
-  delete(data={}, config={}) {
-    return Axios.delete(this.uri(data, config, this.methods['delete']), data, config).then(res => new Response(res));
-  }
-
-  /**
-   * Simple help for building resource paths
-   * @param  {Object} [config={}] [description]
-   * @return {[type]}             [description]
-   */
-  uri(data={}, config={}, pattern='') {
+  url(data={}, config={}, pattern='') {
     let endpoint = `${config.url || this.resource}${pattern}`;
 
     if(config.uri) {
       endpoint += `/${config.uri}`;
     }
 
-    return `${this.server}/${buildSegmentsFromData(data, endpoint)}`;
+    return `${this.server}/${translatePatternSegments(data, endpoint)}`;
   }
+}
+
+//
+// Request Wrapper
+//------------------------------------------------------------------------------------------//
+//
+
+/**
+ * Serves as a single point of entry to all HTTP requests.
+ * @param  {String} [method='get'] [description]
+ * @param  {Object} [config={}]    [description]
+ * @param  {[type]} data           [description]
+ * @return {[type]}                [description]
+ */
+function request(method='get', config={}, data) {
+  config = Object.assign({}, this.config, config);
+  config.url = this.url(data || config.segments, config, this.methods[method]);
+  config.data = data;
+
+  return Axios(new Request(method, config)).then(data => new Response(data));
 }
 
 //
@@ -89,7 +79,16 @@ module.exports = class Resource {
 //------------------------------------------------------------------------------------------//
 // @description
 //
-function buildSegmentsFromData(data, pattern='') {
+
+/**
+ * Takes a url pattern such as: /users/:id (modeled after express.js) and examines the given
+ * object for a matching key wherein it will supplant the value for the placeholder. Uses 'url-pattern'
+ * for the regex.
+ * @param  {[type]} data         [description]
+ * @param  {String} [pattern=''] [description]
+ * @return {[type]}              [description]
+ */
+function translatePatternSegments(data, pattern='') {
   let segments = new Pattern(pattern, {segmentNameCharset: 'a-zA-Z0-9_-'}).names;
 
   segments.forEach(seg => {

--- a/src/resource/request.js
+++ b/src/resource/request.js
@@ -1,0 +1,23 @@
+'use strict';
+
+/***********************************************************************************************************************************************
+ * CONTINUUM - RESOURCE - RESPONSE
+ ***********************************************************************************************************************************************
+ * @description
+ */
+
+/**
+ * Request Class
+ * @description Essentially creates a consistent configuration object for Axios requests.
+ *              The benefit of this is, if we ever decide to change our HTTP library, we can build
+ *              any new configuration here.
+ * @type {[type]}
+ */
+module.exports = class Request {
+  constructor(method='get', config={}) {
+    this.method = method;
+    this.params = config.params || {};
+    this.url = config.url || '',
+    this.data = config.data || {};
+  }
+}

--- a/src/resource/request.js
+++ b/src/resource/request.js
@@ -17,7 +17,9 @@ module.exports = class Request {
   constructor(method='get', config={}) {
     this.method = method;
     this.params = config.params || {};
-    this.url = config.url || '',
+    this.url = config.url || '';
     this.data = config.data || {};
+    this.headers = config.headers || {};
+    this.auth = config.auth || {};
   }
 }

--- a/src/resource/response.js
+++ b/src/resource/response.js
@@ -17,5 +17,6 @@ module.exports = class Response {
     Object.defineProperty(this, 'config', {value: Object.assign({}, response.config || {}), writable: false, enumerable: false});
     Object.defineProperty(this, 'status', {value: response.status, writable: false, enumerable: false});
     Object.defineProperty(this, 'headers', {value: response.headers || {}, writable: false, enumerable: false});
+    console.log(response, this)
   }
 }

--- a/src/resource/response.js
+++ b/src/resource/response.js
@@ -17,6 +17,5 @@ module.exports = class Response {
     Object.defineProperty(this, 'config', {value: Object.assign({}, response.config || {}), writable: false, enumerable: false});
     Object.defineProperty(this, 'status', {value: response.status, writable: false, enumerable: false});
     Object.defineProperty(this, 'headers', {value: response.headers || {}, writable: false, enumerable: false});
-    console.log(response, this)
   }
 }

--- a/tests/unit/resource.js
+++ b/tests/unit/resource.js
@@ -28,9 +28,6 @@ const Users = new Resource('users', {
   base: process.env.API
 });
 
-const spec = {passed: [], failed: []};
-
-
 describe('Continuum - Resource - Retrieval', () => {
   let request = Users.get({params: {_sort: 'created'}, headers: {'Continuum-Request-Header': Math.random().toString(32).substr(2, 16)}});
 
@@ -75,5 +72,13 @@ describe('Continuum - Resource - Retrieval', () => {
       }).then(done).catch(done);
   });
 
-  it('Sould replace dynamic segements in the url', runner.stub);
+  it('Sould replace dynamic segements in the url', (done) => {
+    request.then(response => {
+      let user = response.data[0];
+
+      let url = Users.url(user, {}, Users.methods.put);
+      expect(url).to.contain(user.id);
+
+    }).then(done).catch(done);
+  });
 });


### PR DESCRIPTION
- Resource now uses a Request wrapper to be more consistent with initiating requests.
- Model no longer accepts a `type` config member. It now just auto-detects Array or Object (the only accepted values.)
- Added the delete outbound transform to the Domain delete flow.
- Fulfilled the dynamic segment replacement test.
- Changed package.json unit test to include not inspector. running `npm run tests:unit:headless` will run it without.